### PR TITLE
Remove default components

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -60,12 +60,6 @@ module.exports.AScene = registerElement('a-scene', {
         this.hasLoaded = false;
         this.isPlaying = false;
         this.originalHTML = this.innerHTML;
-
-        // Default components.
-        this.setAttribute('inspector', '');
-        this.setAttribute('keyboard-shortcuts', '');
-        this.setAttribute('screenshot', '');
-        this.setAttribute('vr-mode-ui', '');
       }
     },
 


### PR DESCRIPTION
Removes default components. In hubs...
We don't use the inspector (which seems to be busted).
We disable keyboard-shortcuts.
We don't use the screenshot component, which also create an entity in the scene with a unique shader and webgl program.
We disable vr-mode-ui.
