### PR TITLE
WebGL2 context xrCompatible flag

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -593,7 +593,8 @@ module.exports.AScene = registerElement('a-scene', {
               antialias: rendererConfig.antialias,
               premultipliedAlpha: true,
               preserveDrawingBuffer: false,
-              powerPreference: 'default'
+              powerPreference: 'default',
+              xrCompatible: true
             });
 
             if (context) {


### PR DESCRIPTION
Add `xrCompatible: true` per the [WebXR Device API Specification](https://www.w3.org/TR/webxr/#contextcompatibility) so that destructive context loss is not incurred later in XR setup.

See also https://github.com/mozilla/hubs/issues/1714.