### PR TITLE
Fix WebXR support

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -575,7 +575,6 @@ module.exports.AScene = registerElement('a-scene', {
 
     setupRenderer: {
       value: function () {
-        var self = this;
         var renderer;
         var rendererAttr;
         var rendererAttrString;
@@ -716,10 +715,6 @@ module.exports.AScene = registerElement('a-scene', {
         renderer = this.renderer = new THREE.WebGLRenderer(rendererConfig);
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
-        if (this.camera) { renderer.vr.setPoseTarget(this.camera.el.object3D); }
-        this.addEventListener('camera-set-active', function () {
-          renderer.vr.setPoseTarget(self.camera.el.object3D);
-        });
         loadingScreen.setup(this, getCanvasSize);
       },
       writable: window.debug


### PR DESCRIPTION
Remove use of setPoseTarget. Hubs will grab transform directly from camera object

