### PR TITLE
Use proper THREE.Cache API in a-assets.js

### DIFF
--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -42,7 +42,7 @@ module.exports = registerElement('a-assets', {
           loaded.push(new Promise(function (resolve, reject) {
             // Set in cache because we won't be needing to call three.js loader if we have.
             // a loaded media element.
-            THREE.Cache.files[imgEls[i].getAttribute('src')] = imgEl;
+            THREE.Cache.add(imgEls[i].getAttribute('src'), imgEl);
             imgEl.onload = resolve;
             imgEl.onerror = reject;
           }));
@@ -165,7 +165,7 @@ function mediaElementLoaded (el) {
         // Store video elements only. three.js loader is used for audio elements.
         // See assetParse too.
         if (el.tagName === 'VIDEO') {
-          THREE.Cache.files[el.getAttribute('src')] = el;
+          THREE.Cache.add(el.getAttribute('src'), el);
         }
         resolve();
       }


### PR DESCRIPTION
Related: https://github.com/mozilla/hubs/issues/4258
Related: https://github.com/aframevr/aframe/issues/4861

**Description:**

`a-assets.js` uses `THREE.Cache.files[url] = file;` API, but I don't think we should directly access `THREE.Cache.files` and I think we should use [`THREE.Cache.add(url, file)`](https://threejs.org/docs/#api/en/loaders/Cache.add) which would be more proper API instead.

I also suggested it to the upstreaming A-Frame https://github.com/aframevr/aframe/issues/4861. But I'm not really sure when it will be accepted.

I need this change for https://github.com/mozilla/hubs/issues/4258 because `THREE.Cache.add()` has no effect if `THREE.Cache.enabled = false`. It means we can control `THREE.Cache` enable/disable in Hubs side with `THREE.Cache.enabled = true | false`. Currently A-Frame stores the contents to `THREE.Cache` even if `THREE.Cache.enabled = false`.

So I would like to have this change in our fork, and try to push it to the upstream later.

**Changes proposed:**
- Replace `THREE.Cache.files[url] = file` with `THREE.Cache.add(url, file)` in `a-assets.js`
