### PR TITLE
Bump Three.js into r128

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13170,8 +13170,9 @@
       }
     },
     "three": {
-      "version": "github:mozillareality/three.js#6dc1886802c936054ee5f48e8b39cc1be2e6e45f",
-      "from": "github:mozillareality/three.js#hubs/master",
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
+      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -87,13 +87,13 @@
     "sinon": "^1.17.5",
     "sinon-chai": "2.8.0",
     "snazzy": "^5.0.0",
-    "three": "github:mozillareality/three.js#hubs/master",
+    "three": "^0.128.0",
     "too-wordy": "ngokevin/too-wordy",
     "uglifyjs": "^2.4.10",
     "write-good": "^0.9.1"
   },
   "peerDependencies": {
-    "three": "github:mozillareality/three.js#hubs/master"
+    "three": "^0.128.0"
   },
   "link": true,
   "browserify": {

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -3,7 +3,7 @@ var geometryNames = require('../core/geometry').geometryNames;
 var registerComponent = require('../core/component').registerComponent;
 var THREE = require('../lib/three');
 
-var dummyGeometry = new THREE.Geometry();
+var dummyGeometry = new THREE.BufferGeometry();
 
 /**
  * Geometry component. Combined with material component to make a mesh in 3D object.

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -552,7 +552,7 @@ module.exports.AScene = registerElement('a-scene', {
           return;
         }
 
-        var isPresenting = this.renderer.xr.isPresenting();
+        var isPresenting = this.renderer.xr.isPresenting;
         isVRPresenting = this.renderer.xr.enabled && isPresenting;
 
         // Do not update renderer, if a camera or a canvas have not been injected.

--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -262,7 +262,7 @@ module.exports.AScene = registerElement('a-scene', {
       value: function (useAR) {
         var self = this;
         var vrDisplay;
-        var vrManager = self.renderer.vr;
+        var vrManager = self.renderer.xr;
 
         // Don't enter VR if already in VR.
         if (this.is('vr-mode')) { return Promise.resolve('Already in VR.'); }
@@ -368,7 +368,7 @@ module.exports.AScene = registerElement('a-scene', {
       value: function () {
         var self = this;
         var vrDisplay;
-        var vrManager = this.renderer.vr;
+        var vrManager = this.renderer.xr;
 
         // Don't exit VR if not in VR.
         if (!this.is('vr-mode')) { return Promise.resolve('Not in VR.'); }
@@ -552,8 +552,8 @@ module.exports.AScene = registerElement('a-scene', {
           return;
         }
 
-        var isPresenting = this.renderer.vr.isPresenting();
-        isVRPresenting = this.renderer.vr.enabled && isPresenting;
+        var isPresenting = this.renderer.xr.isPresenting();
+        isVRPresenting = this.renderer.xr.enabled && isPresenting;
 
         // Do not update renderer, if a camera or a canvas have not been injected.
         // In VR mode, three handles canvas resize based on the dimensions returned by
@@ -741,7 +741,7 @@ module.exports.AScene = registerElement('a-scene', {
         this.addEventListener('loaded', function () {
           var renderer = this.renderer;
           var vrDisplay;
-          var vrManager = this.renderer.vr;
+          var vrManager = this.renderer.xr;
           AEntity.prototype.play.call(this);  // .play() *before* render.
 
           if (sceneEl.renderStarted) { return; }

--- a/src/systems/geometry.js
+++ b/src/systems/geometry.js
@@ -1,6 +1,5 @@
 var geometries = require('../core/geometry').geometries;
 var registerSystem = require('../core/system').registerSystem;
-var THREE = require('../lib/three');
 
 /**
  * System for geometry component.
@@ -103,7 +102,7 @@ function createGeometry (data) {
   if (!GeometryClass) { throw new Error('Unknown geometry `' + geometryType + '`'); }
 
   geometryInstance.init(data);
-  return toBufferGeometry(geometryInstance.geometry, data.buffer);
+  return geometryInstance.geometry;
 }
 
 /**
@@ -118,21 +117,4 @@ function decrementCacheCount (cacheCount, hash) {
  */
 function incrementCacheCount (cacheCount, hash) {
   cacheCount[hash] = cacheCount[hash] === undefined ? 1 : cacheCount[hash] + 1;
-}
-
-/**
- * Transform geometry to BufferGeometry if `doBuffer`.
- *
- * @param {object} geometry
- * @param {boolean} doBuffer
- * @returns {object} Geometry.
- */
-function toBufferGeometry (geometry, doBuffer) {
-  var bufferGeometry;
-  if (!doBuffer) { return geometry; }
-
-  bufferGeometry = new THREE.BufferGeometry().fromGeometry(geometry);
-  bufferGeometry.metadata = {type: geometry.type, parameters: geometry.parameters || {}};
-  geometry.dispose();  // Dispose no longer needed non-buffer geometry.
-  return bufferGeometry;
 }

--- a/src/systems/renderer.js
+++ b/src/systems/renderer.js
@@ -35,8 +35,7 @@ module.exports.System = registerSystem('renderer', {
     renderer.physicallyCorrectLights = data.physicallyCorrectLights;
 
     if (data.colorManagement || data.gammaOutput) {
-      renderer.gammaOutput = true;
-      renderer.gammaFactor = 2.2;
+      renderer.outputEncoding = THREE.sRGBEncoding;
       if (data.gammaOutput) {
         warn('Property `gammaOutput` is deprecated. Use `renderer="colorManagement: true;"` instead.');
       }


### PR DESCRIPTION
**Description:**

We are working on bumping Three.js to a newer one for Hubs. Hubs has a dependency with A-Frame and our A-Frame fork needs to be updated for the newer Three.js, too.

**Changes proposed:**
- Update to follow the Three.js r128 API

**Caution**

Please don't merge this PR until Hubs will be updated for the newer Three.js. Otherwise Hubs can be broken.