### PR TITLE
Add workaround for Safari 15 shader compilation problem

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -673,6 +673,21 @@ module.exports.AScene = registerElement('a-scene', {
                   fragmentShader = fragmentShader.replace(versionRegex, '');
                 }
 
+                // Remove derivative #extension directives because it isn't necessary in WebGL2 + GLSL3
+                // and it can cause problem in Safari 15.
+                // See https://github.com/MozillaReality/aframe/pull/32
+
+                if (fragmentShader.indexOf('GL_OES_standard_derivatives') >= 0) {
+                  // Hardcoded chunk may not be flexible.
+                  // But we rarely update our A-Frame shader codes. I hope it is acceptable.
+                  const derivativesExtensionLines = [
+                    '#ifdef GL_OES_standard_derivatives',
+                    '#extension GL_OES_standard_derivatives: enable',
+                    '#endif'
+                  ].join('\n') + '\n';
+                  fragmentShader = fragmentShader.replace(derivativesExtensionLines, '');
+                }
+
                 // GLSL 3.0 conversion
                 const prefixVertex = [
                   '#version 300 es\n',


### PR DESCRIPTION
**Description:**

This PR fixes https://github.com/mozilla/hubs/issues/4656 by moving #extension directives to the top of the shader code after the version specification.

Please refer to https://github.com/mozilla/hubs/issues/4656#issuecomment-924440271 for the details of the root issue.

I first tried to revert the shader code rewrite to GLSL3 for WebGL2 (#5), but I realized that (if I read [MDN](https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives) correctly) we need to use GLSL3 to use derivative functions in WebGL 2. 

Then I decided to go with another approach, removing derivative #extension directives. In WebGL2 + GLSL3 the derivative #extension directives doesn't seem to me necessary.