### PR TITLE
allow catching enterVR error

### DIFF
--- a/src/core/scene/a-scene.js
+++ b/src/core/scene/a-scene.js
@@ -229,7 +229,7 @@ module.exports.AScene = registerElement('a-scene', {
             if (this.xrSession) {
               this.xrSession.removeEventListener('end', this.exitVRBound);
             }
-            navigator.xr.requestSession(useAR ? 'immersive-ar' : 'immersive-vr', {
+            return navigator.xr.requestSession(useAR ? 'immersive-ar' : 'immersive-vr', {
               requiredFeatures: ['local-floor'],
               optionalFeatures: ['bounded-floor']
             }).then(function requestSuccess (xrSession) {
@@ -261,7 +261,7 @@ module.exports.AScene = registerElement('a-scene', {
               attributes: presentationAttributes
             }]).then(enterVRSuccess, enterVRFailure);
           }
-          return Promise.resolve();
+          // return Promise.resolve();
         }
 
         // No VR.


### PR DESCRIPTION
`enterVR` is running asynchronous function `requestSession` without returning its promise, which means we cannot `await` it and potentially catch errors.
It can be useful to catch this error, for example to detect if the user needs to gesture (`SecurityError`) instead of prompting for gesture every time.