### PR TITLE
Bump Three.js to r147

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13170,9 +13170,9 @@
       }
     },
     "three": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
-      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.147.0.tgz",
+      "integrity": "sha512-LPTOslYQXFkmvceQjFTNnVVli2LaVF6C99Pv34fJypp8NbQLbTlu3KinZ0zURghS5zEehK+VQyvWuPZ/Sm8fzw==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "write-good": "^0.9.1"
   },
   "peerDependencies": {
-    "three": "^0.141.0",
+    "three": "^0.147.0",
     "bitecs": "^0.3.38"
   },
   "link": true,


### PR DESCRIPTION
Needed for https://github.com/mozilla/hubs/pull/5852

Current our A-Frame fork seems to block Three.js r147 install in Hubs. It seems to need to upgrade Three.js to r147 in A-Frame, too.