### PR TITLE
[Mozilla Branding Removal] Remove old mozilla repos from console logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ var AEntity = require('./core/a-entity'); // Depends on ANode and core component
 require('./core/a-assets');
 require('./core/a-mixin');
 
-console.log('A-Frame Version: https://github.com/MozillaReality/aframe');
-console.log('three Version: https://github.com/MozillaReality/three.js');
+console.log('A-Frame Version: https://github.com/Hubs-Foundation/aframe');
+console.log('three Version: https://github.com/Hubs-Foundation/three.js');
 
 module.exports = window.AFRAME = {
   AComponent: require('./core/component').Component,


### PR DESCRIPTION
There was not much branding here. 
- I did not touch the code of conduct, this seems to be mostly untouched from the original a-frame source.
- The rest "moz" or "mozilla" is related to the browser or an option for jshint.